### PR TITLE
プロダクト名称をちきゅう → GENIEE SFA/CRM(旧ちきゅう)に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chikyu-sdk-javascript
 ## 概要
-ちきゅうのWeb APIをJavaScript(jQuery)から利用するためのライブラリです。
+GENIEE SFA/CRM(旧ちきゅう)のWeb APIをJavaScript(jQuery)から利用するためのライブラリです。
 
 ＊NodeJSでの利用は想定しておりません。
 
@@ -163,5 +163,5 @@ chikyu.invokeSecure('/entity/prospects/list', {
 
 
 ## APIリスト
-ちきゅう内部にあるチャットツールからCSにお問い合わせください。
+GENIEE SFA/CRM(旧ちきゅう)内部にあるチャットツールからCSにお問い合わせください。
 


### PR DESCRIPTION
背景:https://geniee.slack.com/archives/GB4M765EV/p1738027313299119?thread_ts=1738026852.120789&cid=GB4M765EV