### PR TITLE
《A》未定 SFATB-641 feat: ヘッダーでレスポンスにHTTPステータス要求するオプションと、has_errorがtrueの場合は400を検知できるように

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,42 @@ chikyu.invokeSecure('/entity/prospects/list', {
 });
 ```
 
+### RESTful応答モード（エラー時のHTTPステータスコード返却）
+デフォルトでは、APIエラー（`has_error: true`）でもHTTPステータスは200を返します。
+`setUseHttpStatus(true)`を設定すると、`has_error: true`の場合にHTTPステータス400が返却されるようになります。
+
+```http_status.js
+chikyu = new Chikyu.Sdk();
+
+// RESTful応答モードを有効化（has_errorに合わせてHTTPステータスを変更）
+chikyu.config.setUseHttpStatus(true);
+
+chikyu.login('token_name', 'login_token', 'login_secret_token').then(function(session) {
+  chikyu.invokeSecure('/entity/prospects/list', {
+    'items_per_page': 10,
+    'page_index': 0
+  }).then(function(data, httpStatus) {
+    // 第2引数でHTTPステータスコードを取得可能
+    console.log('HTTP Status:', httpStatus); // 200
+    alert(JSON.stringify(data));
+  }).fail(function(err, httpStatus) {
+    // エラー時（has_error: true）、HTTPステータス400が返る
+    console.log('Error HTTP Status:', httpStatus); // 400
+    alert(JSON.stringify(err));
+  });
+}).fail(function(err, httpStatus) {
+  alert(JSON.stringify(err));
+});
+```
+
+| 設定 | エラー時のHTTPステータス |
+|------|------------------------|
+| `setUseHttpStatus(false)`（デフォルト） | 常に200 |
+| `setUseHttpStatus(true)` | `has_error: true`の場合は400 |
+
+＊`setUseHttpStatus(true)`を設定すると、リクエストに`Error-Response: http-status`ヘッダーが自動付与されます。
+＊HTTPステータスコード自体は第2引数で常に取得可能です。この設定はサーバー側の返却値を変更します。
+
 
 ## APIリスト
 GENIEE SFA/CRM(旧ちきゅう)内部にあるチャットツールからCSにお問い合わせください。

--- a/src/common/config.js
+++ b/src/common/config.js
@@ -47,5 +47,11 @@ Chikyu.Sdk.prototype.config = {
   },
   setMode: function(mode) {
     this._mode = mode;
+  },
+  useHttpStatus: function() {
+    return this._useHttpStatus || false;
+  },
+  setUseHttpStatus: function(flag) {
+    this._useHttpStatus = flag;
   }
 }

--- a/src/common/request.js
+++ b/src/common/request.js
@@ -42,7 +42,7 @@ Chikyu.Sdk.prototype.invoke = function(apiClass, apiPath, apiData, headers, http
             xhr.setRequestHeader(header[0], header[1]);
           });
         }
-    }).done(function(data, textStatus, jqXHR) {
+    }).done(function(data, _, jqXHR) {
       onSuccess(data, jqXHR.status);
     }).fail(function(req, status, error) {
       // responseJSONがある場合はそれを使用

--- a/src/common/request.js
+++ b/src/common/request.js
@@ -71,7 +71,7 @@ Chikyu.Sdk.prototype.invoke = function(apiClass, apiPath, apiData, headers, http
       headers: header_map
     }).success(function(data, status) {
       onSuccess(data, status);
-    }).error(function(data, status, headers, config) {
+    }).error(function(data, status) {
       // HTTPエラーの場合
       if (data && typeof data === 'object') {
         d.reject(data, status);

--- a/src/common/request.js
+++ b/src/common/request.js
@@ -2,17 +2,26 @@ Chikyu.Sdk.prototype.invoke = function(apiClass, apiPath, apiData, headers, http
   if (!headers) {
     headers = [['Content-Type', 'application/json']]
   }
+  headers = headers.slice();
+  if (this.config.useHttpStatus()) {
+    var hasErrorHeader = headers.some(function(h) {
+      return h[0].toLowerCase() === 'error-response';
+    });
+    if (!hasErrorHeader) {
+      headers.push(['Error-Response', 'http-status']);
+    }
+  }
 
   var url = this.buildUrl(apiClass, apiPath);
   var d = $.Deferred();
 
-  var onSuccess = function(data) {
+  var onSuccess = function(data, httpStatus) {
     if (data.has_error) {
       console.log('AJAX Error: ' + data.message);
-      d.reject(data);
+      d.reject(data, httpStatus);
       return;
     }
-    d.resolve(data.data);
+    d.resolve(data.data, httpStatus);
   };
 
   var onError = function(data, status, headers, config) {
@@ -37,10 +46,17 @@ Chikyu.Sdk.prototype.invoke = function(apiClass, apiPath, apiData, headers, http
             xhr.setRequestHeader(header[0], header[1]);
           });
         }
-    }).done(function(data) {
-      onSuccess(data);
+    }).done(function(data, textStatus, jqXHR) {
+      onSuccess(data, jqXHR.status);
     }).fail(function(req, status, error) {
-      onError(req, status, error, null);
+      // responseJSONがある場合はそれを使用
+      if (req.responseJSON) {
+        d.reject(req.responseJSON, req.status);
+        return;
+      }
+      // responseJSONがない場合もエラーオブジェクトを作成
+      var errorData = { has_error: true, message: error || status };
+      d.reject(errorData, req.status);
     });
   } else {
     //AngularJSのhttpオブジェクトを想定。
@@ -57,10 +73,17 @@ Chikyu.Sdk.prototype.invoke = function(apiClass, apiPath, apiData, headers, http
       method: 'POST',
       data: apiData,
       headers: header_map
-    }).success(function(data) {
-      onSuccess(data);
+    }).success(function(data, status) {
+      onSuccess(data, status);
     }).error(function(data, status, headers, config) {
-      onError(data, status, headers, config);
+      // HTTPエラーの場合
+      if (data && typeof data === 'object') {
+        d.reject(data, status);
+        return;
+      }
+      // dataがない場合もエラーオブジェクトを作成
+      var errorData = { has_error: true, message: data || 'Error' };
+      d.reject(errorData, status);
     });
   }
 

--- a/src/common/request.js
+++ b/src/common/request.js
@@ -24,10 +24,6 @@ Chikyu.Sdk.prototype.invoke = function(apiClass, apiPath, apiData, headers, http
     d.resolve(data.data, httpStatus);
   };
 
-  var onError = function(data, status, headers, config) {
-    d.reject(data, status, headers, config);
-  };
-
   if (!http) {
     var payload = JSON.stringify(apiData);
     $.ajax({


### PR DESCRIPTION
背景：

https://geniee.atlassian.net/browse/SFATB-641

## テストケースまとめ

## テスト結果

### テスト概要
通常モード（`setUseHttpStatus(false)`）とRESTfulモード（`setUseHttpStatus(true)`）で同じAPIを実行し、HTTPステータスコードの違いを検証。

### テストケース一覧

#### Open API（認証不要）
| テストケース | 通常モード | RESTfulモード |
|-------------|-----------|--------------|
| token/create（無効パラメータ） | 200（has_error） | **400** |

#### Public API（X-Api-Key認証）
| テストケース | 通常モード | RESTfulモード |
|-------------|-----------|--------------|
| companies/list（正常系） | 200 | 200 |
| companies/create（fieldsなし） | 200（has_error） | **400** |

#### Secure API（AWS署名認証）
| テストケース | 通常モード | RESTfulモード |
|-------------|-----------|--------------|
| session/exists（正常系） | 200 | 200 |
| companies/list（正常系） | 200 | 200 |
| companies/create（fieldsなし） | 200（has_error） | **400** |
| unknown/unknown（存在しないAPI） | 400 | 400 |

#### Signless API（ハッシュ認証）
| テストケース | 通常モード | RESTfulモード |
|-------------|-----------|--------------|
| companies/list（正常系） | 200 | 200 |
| companies/create（fieldsなし） | 200（has_error） | **400** |
| companies/save（fieldsなし） | 200（has_error） | **400** |
| companies/delete（存在しないID） | 200（has_error） | **400** |
| companies/list（items_per_pageなし） | 200（has_error） | **400** |
| unknown/unknown（存在しないAPI） | 400 | 400 |
| sandbox/status | 200 | 200 |

### 後方互換性

```javascript
// 既存の書き方（引き続き動作）
sdk.invokeSecure('/entity/companies/list', data)
  .then(function(data) { ... })
  .fail(function(err) { ... });

// 新しい書き方（HTTPステータス取得可能）
sdk.invokeSecure('/entity/companies/list', data)
  .then(function(data, httpStatus) { ... })
  .fail(function(err, httpStatus) { ... });
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * レスポンスの「RESTfulモード」を切替える設定を追加。エラー時のHTTPステータス（例: has_error→400）を有効化可能。
  * SDKが自動でError-Responseヘッダーを付与し、成功/失敗コールバックでHTTPステータスを受け取れるようになりました。

* **ドキュメント**
  * RESTful応答モードの動作説明、設定方法、利用例、クイックリファレンスをREADMEに追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->